### PR TITLE
Update WSO2 CloudFormation templates from SP 4.2.0 to SP 4.3.0

### DIFF
--- a/ha-deployment/ha-deployment.yaml
+++ b/ha-deployment/ha-deployment.yaml
@@ -267,16 +267,24 @@ Resources:
           ToPort: '9443'
           SourceSecurityGroupId: !Ref WSO2SPLoadBalancerSecurityGroup
         - IpProtocol: tcp
-          FromPort: '8243'
-          ToPort: '8243'
-          SourceSecurityGroupId: !Ref WSO2SPLoadBalancerSecurityGroup
+          FromPort: '7711'
+          ToPort: '7711'
+          CidrIp: 0.0.0.0/0
         - IpProtocol: tcp
-          FromPort: '5672'
-          ToPort: '5672'
-          SourceSecurityGroupId: !Ref WSO2SPLoadBalancerSecurityGroup
+          FromPort: '7611'
+          ToPort: '7611'
+          CidrIp: 0.0.0.0/0
         - IpProtocol: tcp
-          FromPort: '5701'
-          ToPort: '5701'
+          FromPort: '7070'
+          ToPort: '7070'
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: '7443'
+          ToPort: '7443'
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: '9444'
+          ToPort: '9444'
           CidrIp: 0.0.0.0/0
         - IpProtocol: tcp
           FromPort: '8140'
@@ -290,7 +298,7 @@ Resources:
       ImageId: !FindInMap
         - WSO2SPAMIRegionMap
         - !Ref 'AWS::Region'
-        - Ubuntu140464bit
+        - Ubuntu180464bit
       InstanceType: t2.micro
       KeyName: !Ref KeyPairName
       Monitoring: 'false'
@@ -312,7 +320,7 @@ Resources:
       ImageId: !FindInMap
         - WSO2PuppetMasterRegionMap
         - !Ref 'AWS::Region'
-        - Ubuntu140464bit
+        - Ubuntu180464bit
       InstanceType: !Ref WSO2InstanceType
       KeyName: !Ref KeyPairName
       Monitoring: 'false'
@@ -336,7 +344,7 @@ Resources:
             - hostname puppetmaster
             - echo $(hostname) >> /etc/hostname
             - echo "127.0.0.1 $(hostname)" >> /etc/hosts
-            - sed -i '/\[main\]/a dns_alt_names=puppetmaster,puppet\nenvironmentpath=$confdir/environments\nhiera_config=/etc/puppet/hiera.yaml' /etc/puppet/puppet.conf
+            - sed -i '/\[main\]/a dns_alt_names=puppetmaster,puppet' /etc/puppet/puppet.conf
             - sed -i '/\[master\]/a autosign=true' /etc/puppet/puppet.conf
             - service puppetmaster restart
             - !Sub "./home/ubuntu/sp-init.sh ${WUMUsername} ${WUMPassword}"
@@ -348,79 +356,24 @@ Resources:
                   - DNSName
                 - >-
                   /g"
-                  /etc/puppet/hieradata/dev/wso2/wso2sp/pattern-1/default.yaml
+                  /etc/puppet/code/environments/production/modules/sp_worker/manifests/params.pp
             - !Join
               - ''
               - - sed -i "s/CF_DB_USERNAME/
                 - !Ref DBUsername
-                - /g" /etc/puppet/hieradata/dev/wso2/common.yaml
+                - /g" /etc/puppet/code/environments/production/modules/sp_worker/manifests/params.pp
             - !Join
               - ''
               - - sed -i "s/CF_DB_PASSWORD/
                 - !Ref DBPassword
-                - /g" /etc/puppet/hieradata/dev/wso2/common.yaml
-            - !Join
-              - ''
-              - - sed -i "s/JDK_VERSION/
-                - 'jdk-8u144-linux-x64.tar.gz'
-                - /g" /etc/puppet/hieradata/dev/wso2/common.yaml
+                - /g" /etc/puppet/code/environments/production/modules/sp_worker/manifests/params.pp
             - !Join
               - ''
               - - sed -i "s/CF_RDS_URL/
                 - !GetAtt
                   - WSO2SPDBInstance
                   - Endpoint.Address
-                - /g" /etc/puppet/hieradata/dev/wso2/common.yaml
-  PuppetMasterSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
-    Properties:
-      VpcId: !Ref WSO2SPVPC
-      GroupDescription: WSO2 PuppetMaster Security Group
-      SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIp: 0.0.0.0/0
-        - IpProtocol: tcp
-          FromPort: '8140'
-          ToPort: '8140'
-          CidrIp: 0.0.0.0/0
-  WSO2SPNode1LaunchConfiguration:
-    Type: 'AWS::AutoScaling::LaunchConfiguration'
-    Properties:
-      ImageId: !FindInMap
-        - WSO2SPAMIRegionMap
-        - !Ref 'AWS::Region'
-        - Ubuntu140464bit
-      InstanceType: !Ref WSO2InstanceType
-      BlockDeviceMappings:
-        - DeviceName: /dev/sda1
-          Ebs:
-            VolumeSize: '20'
-            VolumeType: gp2
-            DeleteOnTermination: 'true'
-      KeyName: !Ref KeyPairName
-      SecurityGroups:
-        - !Ref WSO2SPSecurityGroup
-      UserData: !Base64
-        'Fn::Join':
-          - |+
-
-          - - '#!/bin/bash'
-            - 'export PATH=~/.local/bin:$PATH'
-            - apt-get update
-            - apt-get install -y nfs-common
-            - sed -i '/\[main\]/a server=puppet' /etc/puppet/puppet.conf
-            - !Join
-              - ''
-              - - export PuppetmasterIP=
-                - !GetAtt
-                  - PuppetMaster
-                  - PrivateIp
-            - echo "${PuppetmasterIP} puppet puppetmaster" >> /etc/hosts
-            - !Sub "./home/ubuntu/set_jdk.sh jdk-8u144-linux-x64.tar.gz"
-            - mkdir -p /mnt/efs
-            - !Sub "mount -t nfs4 -o nfsvers=4.1 ${WSO2SPEFSFileSystem}.efs.${AWS::Region}.amazonaws.com:/ /mnt/efs"
+                - /g" /etc/puppet/code/environments/production/modules/sp_worker/manifests/params.pp
             - export DB_NAME=WSO2_SP_DB
             - !Join
               - ''
@@ -466,37 +419,73 @@ Resources:
                   - WSO2SPDBInstance
                   - Endpoint.Port
                 - /g" /usr/local/bin/provision_db_sp.sh
-            - sleep 400
-            - sudo /opt/setup.sh start
-            - sleep 60
+            - bash /usr/local/bin/provision_db_sp.sh
+  PuppetMasterSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      VpcId: !Ref WSO2SPVPC
+      GroupDescription: WSO2 PuppetMaster Security Group
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: '8140'
+          ToPort: '8140'
+          CidrIp: 0.0.0.0/0
+  WSO2SPNode1LaunchConfiguration:
+    Type: 'AWS::AutoScaling::LaunchConfiguration'
+    Properties:
+      ImageId: !FindInMap
+        - WSO2SPAMIRegionMap
+        - !Ref 'AWS::Region'
+        - Ubuntu180464bit
+      InstanceType: !Ref WSO2InstanceType
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeSize: '20'
+            VolumeType: gp2
+            DeleteOnTermination: 'true'
+      KeyName: !Ref KeyPairName
+      SecurityGroups:
+        - !Ref WSO2SPSecurityGroup
+      UserData: !Base64
+        'Fn::Join':
+          - |+
+
+          - - '#!/bin/bash'
+            - 'export PATH=~/.local/bin:$PATH'
+            - apt-get update
+            - apt-get install -y puppet
+            - apt-get install -y nfs-common
+            - sed -i '/\[main\]/a server=puppet' /etc/puppet/puppet.conf
             - !Join
               - ''
-              - - sed -i "s/RDS_URL/
+              - - export PuppetmasterIP=
                 - !GetAtt
-                  - WSO2SPDBInstance
-                  - Endpoint.Address
-                - >-
-                  /g"
-                  /mnt/wso2sp-4.2.0/conf/worker/deployment.yaml
+                  - PuppetMaster
+                  - PrivateIp
+            - echo "${PuppetmasterIP} puppet puppetmaster" >> /etc/hosts
+            - service puppet restart
+            - mkdir -p /mnt/efs
+            - !Sub "mount -t nfs4 -o nfsvers=4.1 ${WSO2SPEFSFileSystem}.efs.${AWS::Region}.amazonaws.com:/ /mnt/efs"
+            - sleep 400
+            - export FACTER_profile=sp_worker
+            - puppet agent -vt
+            - sleep 60
+            - apt-get install -y python3-pip
+            - pip3 install boto3
+            - !Sub "PRIVATE_IP=$(python3 /usr/local/bin/private_ip_extractor.py ${AWS::Region} ${AWSAccessKeyId} ${AWSAccessKeySecret} WSO2SPInstance1)"
             - !Join
               - ''
               - - sed -i "s/HOST_ID/
-                - 'wso2-sp-1'
+                - $PRIVATE_IP
                 - >-
                   /g"
-                  /mnt/wso2sp-4.2.0/conf/worker/deployment.yaml
-            - !Join
-              - ''
-              - - sed -i "s/RDS_USERNAME/
-                - !Ref DBUsername
-                -  /g"  /mnt/wso2sp-4.2.0/conf/worker/deployment.yaml
-            - !Join
-              - ''
-              - - sed -i "s/RDS_PASSWORD/
-                - !Ref DBPassword
-                -  /g"  /mnt/wso2sp-4.2.0/conf/worker/deployment.yaml
-            - bash /usr/local/bin/provision_db_sp.sh
-            - /mnt/wso2sp-4.2.0/wso2/worker/bin/carbon.sh start
+                  /usr/lib/wso2/wso2sp/4.3.0/wso2sp-4.3.0/conf/worker/deployment.yaml
+            - /usr/lib/wso2/wso2sp/4.3.0/wso2sp-4.3.0/bin/worker.sh start
             - echo 'export HISTTIMEFORMAT="%F %T "' >> /etc/profile.d/history.sh
             - cat /dev/null > ~/.bash_history && history -c
     DependsOn:
@@ -532,7 +521,7 @@ Resources:
       ImageId: !FindInMap
         - WSO2SPAMIRegionMap
         - !Ref 'AWS::Region'
-        - Ubuntu140464bit
+        - Ubuntu180464bit
       InstanceType: !Ref WSO2InstanceType
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
@@ -550,6 +539,7 @@ Resources:
           - - '#!/bin/bash'
             - 'export PATH=~/.local/bin:$PATH'
             - apt-get update
+            - apt-get install -y puppet
             - apt-get install -y nfs-common
             - sed -i '/\[main\]/a server=puppet' /etc/puppet/puppet.conf
             - !Join
@@ -559,85 +549,24 @@ Resources:
                   - PuppetMaster
                   - PrivateIp
             - echo "${PuppetmasterIP} puppet puppetmaster" >> /etc/hosts
-            - !Sub "./home/ubuntu/set_jdk.sh jdk-8u144-linux-x64.tar.gz"
+            - service puppet restart
             - mkdir -p /mnt/efs
             - !Sub "mount -t nfs4 -o nfsvers=4.1 ${WSO2SPEFSFileSystem}.efs.${AWS::Region}.amazonaws.com:/ /mnt/efs"
-            - export DB_NAME=WSO2_SP_DB
-            - !Join
-              - ''
-              - - export DB_HOSTNAME=
-                - !GetAtt
-                  - WSO2SPDBInstance
-                  - Endpoint.Address
-            - !Join
-              - ''
-              - - export DB_PORT=
-                - !GetAtt
-                  - WSO2SPDBInstance
-                  - Endpoint.Port
-            - !Join
-              - ''
-              - - export DB_USERNAME=
-                - !Ref DBUsername
-            - !Join
-              - ''
-              - - export DB_PASSWORD=
-                - !Ref DBPassword
-            - !Join
-              - ''
-              - - sed -i "s/CF_DB_USERNAME/
-                - !Ref DBUsername
-                - /g" /usr/local/bin/provision_db_sp.sh
-            - !Join
-              - ''
-              - - sed -i "s/CF_DB_PASSWORD/
-                - !Ref DBPassword
-                - /g" /usr/local/bin/provision_db_sp.sh
-            - !Join
-              - ''
-              - - sed -i "s/CF_DB_HOST/
-                - !GetAtt
-                  - WSO2SPDBInstance
-                  - Endpoint.Address
-                - /g" /usr/local/bin/provision_db_sp.sh
-            - !Join
-              - ''
-              - - sed -i "s/CF_DB_PORT/
-                - !GetAtt
-                  - WSO2SPDBInstance
-                  - Endpoint.Port
-                - /g" /usr/local/bin/provision_db_sp.sh
             - sleep 400
-            - sudo /opt/setup.sh start
+            - export FACTER_profile=sp_worker
+            - puppet agent -vt
             - sleep 60
-            - !Join
-              - ''
-              - - sed -i "s/RDS_URL/
-                - !GetAtt
-                  - WSO2SPDBInstance
-                  - Endpoint.Address
-                - >-
-                  /g"
-                  /mnt/wso2sp-4.2.0/conf/worker/deployment.yaml
+            - apt-get install -y python3-pip
+            - pip3 install boto3
+            - !Sub "PRIVATE_IP=$(python3 /usr/local/bin/private_ip_extractor.py ${AWS::Region} ${AWSAccessKeyId} ${AWSAccessKeySecret} WSO2SPInstance2)"
             - !Join
               - ''
               - - sed -i "s/HOST_ID/
-                - 'wso2-sp-2'
+                - $PRIVATE_IP
                 - >-
                   /g"
-                  /mnt/wso2sp-4.2.0/conf/worker/deployment.yaml
-            - !Join
-              - ''
-              - - sed -i "s/RDS_USERNAME/
-                - !Ref DBUsername
-                -  /g"  /mnt/wso2sp-4.2.0/conf/worker/deployment.yaml
-            - !Join
-              - ''
-              - - sed -i "s/RDS_PASSWORD/
-                - !Ref DBPassword
-                -  /g"  /mnt/wso2sp-4.2.0/conf/worker/deployment.yaml
-            - bash /usr/local/bin/provision_db_sp.sh
-            - /mnt/wso2sp-4.2.0/wso2/worker/bin/carbon.sh start
+                  /usr/lib/wso2/wso2sp/4.3.0/wso2sp-4.3.0/conf/worker/deployment.yaml
+            - /usr/lib/wso2/wso2sp/4.3.0/wso2sp-4.3.0/bin/worker.sh start
             - echo 'export HISTTIMEFORMAT="%F %T "' >> /etc/profile.d/history.sh
             - cat /dev/null > ~/.bash_history && history -c
     DependsOn:
@@ -825,27 +754,27 @@ Parameters:
 Mappings:
   WSO2PuppetMasterRegionMap:
     ap-southeast-2:
-      Ubuntu140464bit: ami-0a0075377e2fc407d
+      Ubuntu180464bit: ami-005d8154207e981a4
     eu-west-1:
-      Ubuntu140464bit: ami-0ef32aec34e07c718
+      Ubuntu180464bit: ami-0ea3b70805378f796
     us-east-1:
-      Ubuntu140464bit: ami-008d181a63651b582
+      Ubuntu180464bit: ami-04db6acce789912b4
     us-east-2:
-      Ubuntu140464bit: ami-0148befd98fb35693
+      Ubuntu180464bit: ami-0e8d8e6d8d5498378
     us-west-1:
-      Ubuntu140464bit: ami-0fe9d57d64d67a03a
+      Ubuntu180464bit: ami-01c303b902735f14b
     us-west-2:
-      Ubuntu140464bit: ami-01bbc34c5b696d065
+      Ubuntu180464bit: ami-0b0d60d0d5ed5c8c6
   WSO2SPAMIRegionMap:
     ap-southeast-2:
-      Ubuntu140464bit: ami-00868c7704066f7e7
+      Ubuntu180464bit: ami-07a3bd4944eb120a0
     eu-west-1:
-      Ubuntu140464bit: ami-0758d0932b58097d7
+      Ubuntu180464bit: ami-00035f41c82244dab
     us-east-1:
-      Ubuntu140464bit: ami-0eafb76b98a4e3153
+      Ubuntu180464bit: ami-0ac019f4fcb7cb7e6
     us-east-2:
-      Ubuntu140464bit: ami-0b13a89c659629c6e
+      Ubuntu180464bit: ami-0f65671a86f061fcd
     us-west-1:
-      Ubuntu140464bit: ami-0d0c93929c5e48503
+      Ubuntu180464bit: ami-063aa838bd7631e0b
     us-west-2:
-      Ubuntu140464bit: ami-014a1fecdd62ad231
+      Ubuntu180464bit: ami-0bbe6b35405ecebdb


### PR DESCRIPTION
## Purpose
> Update WSO2 CloudFormation templates from SP 4.2.0 to SP 4.3.0 using Puppet 5 modules in Ubuntu 18.04.

## Test environment
> JDK - OpenJDK 1.8.0_192
> OS - Ubuntu 18.04